### PR TITLE
Ansible linter

### DIFF
--- a/.github/workflows/github_hosted_ci.yml
+++ b/.github/workflows/github_hosted_ci.yml
@@ -14,4 +14,4 @@ jobs:
       - name: Lint Ansible Playbook
         uses: ansible/ansible-lint-action@v4.1.0
         with:
-          args: "self-hosted-runners/ubuntu-vagrant/playbook.yml"
+          targets: "self-hosted-runners/ubuntu-vagrant/playbook.yml"

--- a/.github/workflows/github_hosted_ci.yml
+++ b/.github/workflows/github_hosted_ci.yml
@@ -1,0 +1,17 @@
+name: GitHub-hosted CI example
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show directory listing
+        shell: bash -l {0}
+        run: |
+          ls -la
+      - name: Lint Ansible Playbook
+        uses: ansible/ansible-lint-action@v4.1.0
+        with:
+          args: "self-hosted-runners/ubuntu-vagrant/playbook.yml"

--- a/.github/workflows/github_hosted_ci.yml
+++ b/.github/workflows/github_hosted_ci.yml
@@ -14,4 +14,8 @@ jobs:
       - name: Lint Ansible Playbook
         uses: ansible/ansible-lint-action@v4.1.0
         with:
-          targets: "self-hosted-runners/ubuntu-vagrant/playbook.yml"
+          targets: |
+           ubuntu-vagrant/runner/playbook.yml
+           ubuntu-surf-hpc-cloud/runner/playbook.yml
+           ubuntu-virtualbox/runner/playbook.yml
+           windows-vagrant/runner/playbook.yml


### PR DESCRIPTION
updated the github_hosted_ci.yml to add the anisble-lint action. For now it lints only one file playdoc file. Ther are different options to link multiple files see comment in  https://github.com/ci-for-science/self-hosted-runners/issues/11#issuecomment-651613081