### PR TITLE
Ubuntu virtualbox tokens and tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@
 # link checker
 /node_modules
 
-# anything labeled secret
+# anything labeled secret...
 /**/*/*secret*
+#...except the template file
+!/ubuntu-virtualbox/secret.yml.template

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 # link checker
 /node_modules
+
+# anything labeled secret
+/**/*/*secret*

--- a/docs/install-cuda/playbook-install-cuda-gridk2.yml
+++ b/docs/install-cuda/playbook-install-cuda-gridk2.yml
@@ -32,13 +32,13 @@
     args:
       creates: /usr/bin/g++
 
-  - name: Ensures {{download_path}} dir exists
-    file: path={{download_path}} state=directory
+  - name: Ensures {{ download_path }} dir exists
+    file: path={{ download_path }} state=directory
 
   - name: Download Nvidia driver
     get_url:
-      url: http://us.download.nvidia.com/XFree86/Linux-x86_64/{{driver_version}}/NVIDIA-Linux-x86_64-{{driver_version}}.run
-      dest: /tmp/installers/NVIDIA-Linux-x86_64-{{driver_version}}.run
+      url: http://us.download.nvidia.com/XFree86/Linux-x86_64/{{ driver_version }}/NVIDIA-Linux-x86_64-{{ driver_version }}.run
+      dest: /tmp/installers/NVIDIA-Linux-x86_64-{{ driver_version }}.run
     tags:
       - cuda
 
@@ -49,8 +49,8 @@
 
   - name: Download CUDA
     get_url:
-      url: https://developer.nvidia.com/compute/cuda/{{cuda_version_major}}/Prod2/local_installers/cuda_{{cuda_version_major}}.{{cuda_version_minor}}_linux-run
-      dest: /tmp/installers/cuda_{{cuda_version_major}}.{{cuda_version_minor}}_linux-run
+      url: https://developer.nvidia.com/compute/cuda/{{ cuda_version_major }}/Prod2/local_installers/cuda_{{ cuda_version_major }}.{{ cuda_version_minor }}_linux-run
+      dest: /tmp/installers/cuda_{{ cuda_version_major }}.{{ cuda_version_minor }}_linux-run
     tags:
       - cuda
 
@@ -87,8 +87,8 @@
     blockinfile:
       dest: "/etc/profile.d/cuda.sh"
       block: |
-        export PATH=$PATH:/usr/local/cuda-{{cuda_version_major}}/bin
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-{{cuda_version_major}}/lib64
+        export PATH=$PATH:/usr/local/cuda-{{ cuda_version_major }}/bin
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-{{ cuda_version_major }}/lib64
       marker: '# {mark} CUDA environment variables'
       insertbefore: BOF
       create: yes

--- a/ubuntu-vagrant/playbook.yml
+++ b/ubuntu-vagrant/playbook.yml
@@ -9,7 +9,7 @@
       user:
         name: '{{ runner_user }}'
         state: present
-    - name: Passwordless sudo for {{ runner_user }} user 
+    - name: Passwordless sudo for {{ runner_user }} user
       lineinfile:
         path: /etc/sudoers.d/{{ runner_user }}
         line: '{{ runner_user }} ALL=(ALL) NOPASSWD: ALL'
@@ -20,7 +20,7 @@
     - name: Only run "update_cache=yes" if the last one is more than 3600 seconds ago
       apt:
         update_cache: yes
-        cache_valid_time: 3600        
+        cache_valid_time: 3600
     - name: Setup Docker engine
       include_role:
         name: nickjj.docker

--- a/ubuntu-virtualbox/README.md
+++ b/ubuntu-virtualbox/README.md
@@ -210,16 +210,16 @@ generate an OAuth token, as follows:
 
     ![Token permissions](/images/token_permissions.png)
 
-1. Click ``Generate`` at the bottom. Make sure to copy its value because we'll need it in the next step
+1. Click ``Generate`` at the bottom, and update the value of ``PERSONAL_ACCESS_TOKEN`` in ``secret.yml``.
 
-Configuring your server such that it can run continuous integration requires 5 pieces of information, for which you will be prompted:
+Configuring your server such that it can run continuous integration requires 4 pieces of information, for which you will be prompted:
 
 1. Because our playbook requires elevated permissions, the command uses the ``--ask-become-pass`` option to prompt for
 the root password. Fill in the password ``password`` to become ``root`` in the server.
 1. Fill in the GitHub organization (which might be simply your GitHub user name) and ...
 1. ...the repository name for which you want to run workflows on a self-hosted server
 1. Specify how you want the runner to show up in the GitHub interface
-1. Finally, you need to supply the Personal Access Token
+
 
 Now run this command to provision the GitHub Action runner on your server:
 

--- a/ubuntu-virtualbox/README.md
+++ b/ubuntu-virtualbox/README.md
@@ -203,6 +203,11 @@ from scratch, or make use of tasks that have been published by others (see https
 We're almost ready to use ``ansible-playbook`` to set up a GitHub Runner on your own server, but first we need to
 generate an OAuth token, as follows:
 
+1. Copy ``secret.yml.template`` to ``secret.yml``
+
+    ```
+    cp secret.yml.template secret.yml
+    ```
 1. Go to [https://github.com/settings/tokens](https://github.com/settings/tokens) and click the ``Generate new token`` button.
 1. Provide your GitHub password when prompted
 1. Fill in a description for the token, for example _Token for self-hosted GitHub runners_

--- a/ubuntu-virtualbox/README.md
+++ b/ubuntu-virtualbox/README.md
@@ -203,7 +203,7 @@ from scratch, or make use of tasks that have been published by others (see https
 We're almost ready to use ``ansible-playbook`` to set up a GitHub Runner on your own server, but first we need to
 generate an OAuth token, as follows:
 
-1. Copy ``secret.yml.template`` to ``secret.yml``
+1. Make a copy of the template file. We will store your token in the copied file momentarily.
 
     ```
     cp secret.yml.template secret.yml
@@ -215,7 +215,7 @@ generate an OAuth token, as follows:
 
     ![Token permissions](/images/token_permissions.png)
 
-1. Click ``Generate`` at the bottom, and update the value of ``PERSONAL_ACCESS_TOKEN`` in ``secret.yml``.
+1. Click ``Generate`` at the bottom, and update the value of ``PERSONAL_ACCESS_TOKEN`` in ``secret.yml``. **Don't share the contents of ``secret.yml``.**
 
 Configuring your server such that it can run continuous integration requires 4 pieces of information, for which you will be prompted:
 

--- a/ubuntu-virtualbox/README.md
+++ b/ubuntu-virtualbox/README.md
@@ -205,19 +205,20 @@ generate an OAuth token, as follows:
 
 1. Go to [https://github.com/settings/tokens](https://github.com/settings/tokens) and click the ``Generate new token`` button.
 1. Provide your GitHub password when prompted
-1. Fill in a description for the token, for example _GitHub runner for github.com/&lt;your organization&gt;/&lt;your repository&gt;_
+1. Fill in a description for the token, for example _Token for self-hosted GitHub runners_
 1. Enable the ``repo`` scope and all of its checkboxes, like so:
 
     ![Token permissions](/images/token_permissions.png)
 
 1. Click ``Generate`` at the bottom. Make sure to copy its value because we'll need it in the next step
 
-Configuring your server such that it can run continuous integration requires 4 pieces of information, for which you will be prompted:
+Configuring your server such that it can run continuous integration requires 5 pieces of information, for which you will be prompted:
 
 1. Because our playbook requires elevated permissions, the command uses the ``--ask-become-pass`` option to prompt for
 the root password. Fill in the password ``password`` to become ``root`` in the server.
 1. Fill in the GitHub organization (which might be simply your GitHub user name) and ...
 1. ...the repository name for which you want to run workflows on a self-hosted server
+1. Specify how you want the runner to show up in the GitHub interface
 1. Finally, you need to supply the Personal Access Token
 
 Now run this command to provision the GitHub Action runner on your server:
@@ -303,4 +304,4 @@ You can see a record of past and current GitHub Actions by pointing your browser
 
 ### What's next
 
-Find instructions for provisioning additional functionality [here](../README.md).
+Find instructions for provisioning additional functionality [here](/README.md).

--- a/ubuntu-virtualbox/playbook.yml
+++ b/ubuntu-virtualbox/playbook.yml
@@ -73,6 +73,8 @@
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
       become: yes
       command: ./svc.sh install
+      creates:
+        - /etc/systemd/system/actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
 
     - name: Enable starting the runner service when the machine starts
       become: yes

--- a/ubuntu-virtualbox/playbook.yml
+++ b/ubuntu-virtualbox/playbook.yml
@@ -28,28 +28,17 @@
       debug:
         msg: "Setting up a GitHub runner {{ RUNNER_NAME }} for repository: https://github.com/{{ ORG }}/{{ REPO }}"
 
-    - name: Only run "apt update-cache" if the last one is more than 3600 seconds old
-      become: yes
-      apt:
-        update_cache: yes
-        cache_valid_time: 3600
-
-    - name: Install jq
-      become: yes
-      apt:
-        name:
-          - jq
-          - curl
-        state: present
-
     - name: Requesting registration
-      shell:
-        cmd: "curl -sX POST -H \"Authorization: token {{ PERSONAL_ACCESS_TOKEN }}\" \"https://api.github.com/repos/{{ ORG }}/{{ REPO }}/actions/runners/registration-token\" | jq .token --raw-output"
-      register: CURL_OUTPUT
+      uri:
+        url: https://api.github.com/repos/{{ ORG }}/{{ REPO }}/actions/runners/registration-token
+        method: POST
+        headers:
+          Authorization: "Token {{ PERSONAL_ACCESS_TOKEN }}"
+          Accept: "application/json"
+        status_code: 201
+      register: URI_OUTPUT
       tags:
         - uninstall
-      args:
-        warn: false
 
     - name: Creating a directory for the runner
       file:
@@ -67,7 +56,7 @@
       args:
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
         creates: .runner
-      command: ./config.sh --url https://github.com/{{ ORG }}/{{ REPO }} --name {{ RUNNER_NAME }} --token {{ CURL_OUTPUT.stdout }} --unattended --replace
+      command: ./config.sh --url https://github.com/{{ ORG }}/{{ REPO }} --name {{ RUNNER_NAME }} --token {{ URI_OUTPUT['json']['token'] }} --unattended --replace
 
     - name: Install the GitHub Action runner as a service
       args:
@@ -133,7 +122,7 @@
       args:
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
         removes: .runner
-      command: ./config.sh remove --token {{ CURL_OUTPUT.stdout }}
+      command: ./config.sh remove --token {{ URI_OUTPUT['json']['token'] }}
       tags:
         - never
         - uninstall

--- a/ubuntu-virtualbox/playbook.yml
+++ b/ubuntu-virtualbox/playbook.yml
@@ -71,10 +71,9 @@
     - name: Install the GitHub Action runner as a service
       args:
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
+        creates: /etc/systemd/system/actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
       become: yes
       command: ./svc.sh install
-      creates:
-        - /etc/systemd/system/actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
 
     - name: Enable starting the runner service when the machine starts
       become: yes

--- a/ubuntu-virtualbox/playbook.yml
+++ b/ubuntu-virtualbox/playbook.yml
@@ -64,15 +64,15 @@
         remote_src: yes
 
     - name: Configuring the GitHub Action runner
-      shell:
+      args:
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
-        cmd: ./config.sh --url https://github.com/{{ ORG }}/{{ REPO }} --name {{ RUNNER_NAME }} --token {{ CURL_OUTPUT.stdout }} --unattended --replace
+      command: ./config.sh --url https://github.com/{{ ORG }}/{{ REPO }} --name {{ RUNNER_NAME }} --token {{ CURL_OUTPUT.stdout }} --unattended --replace
 
     - name: Install the GitHub Action runner as a service
-      become: yes
-      shell:
+      args:
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
-        cmd: ./svc.sh install
+      become: yes
+      command: ./svc.sh install
 
     - name: Enable starting the runner service when the machine starts
       become: yes
@@ -118,18 +118,18 @@
         - restart
 
     - name: Unregister the runner with GitHub
-      become: yes
-      shell:
+      args:
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
-        cmd: ./svc.sh uninstall
+      become: yes
+      command: ./svc.sh uninstall
       tags:
         - never
         - uninstall
 
     - name: Uninstall the runner service
-      shell:
+      args:
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
-        cmd: ./config.sh remove --token {{ CURL_OUTPUT.stdout }}
+      command: ./config.sh remove --token {{ CURL_OUTPUT.stdout }}
       tags:
         - never
         - uninstall

--- a/ubuntu-virtualbox/playbook.yml
+++ b/ubuntu-virtualbox/playbook.yml
@@ -19,7 +19,7 @@
 
   tasks:
     - name: Verify that user exists on the server
-      become: True
+      become: yes
       user:
         name: "{{ ansible_user }}"
         groups: sudo,adm
@@ -30,13 +30,13 @@
         msg: "Setting up a GitHub runner for repository: https://github.com/{{ ORG }}/{{ REPO }}"
 
     - name: Only run "apt update-cache" if the last one is more than 3600 seconds old
-      become: True
+      become: yes
       apt:
         update_cache: yes
         cache_valid_time: 3600
 
     - name: Install jq
-      become: True
+      become: yes
       apt:
         name:
           - jq
@@ -70,53 +70,53 @@
         cmd: ./config.sh --url https://github.com/{{ ORG }}/{{ REPO }} --name {{ RUNNER_NAME }} --token {{ CURL_OUTPUT.stdout }} --unattended --replace
 
     - name: Install the GitHub Action runner as a service
-      become: True
+      become: yes
       shell:
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}
         cmd: ./svc.sh install
 
     - name: Enable starting the runner service when the machine starts
-      become: True
+      become: yes
       shell: systemctl enable actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
       tags:
         - enable
 
     - name: Starting the runner service
-      become: True
+      become: yes
       shell: systemctl start actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
       tags:
         - start
 
     - name: Stopping the runner service
-      become: True
+      become: yes
       shell: systemctl stop actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
       tags:
         - never
         - stop
 
     - name: Disable starting the runner service when the system boots
-      become: True
+      become: yes
       shell: systemctl disable actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
       tags:
         - never
         - disable
 
     - name: Restart the runner service
-      become: True
+      become: yes
       shell: systemctl restart actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
       tags:
         - never
         - restart
 
     - name: Show the runner service status
-      become: True
+      become: yes
       shell: systemctl status actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
       tags:
         - never
         - status
 
     - name: Unregister the runner with GitHub
-      become: True
+      become: yes
       shell:
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}
         cmd: ./svc.sh uninstall

--- a/ubuntu-virtualbox/playbook.yml
+++ b/ubuntu-virtualbox/playbook.yml
@@ -6,19 +6,16 @@
     - name: "ORG"
       prompt: "What is the GitHub organization associated with this self-hosted runner?"
       private: no
-      default: jspaaks
     - name: "REPO"
       prompt: "What is the GitHub repository associated with this self-hosted runner?"
       private: no
-      default: example-python-1
     - name: "RUNNER_NAME"
       prompt: "Under what name should the runner show up on GitHub?"
       private: no
-      default: therunner1
+      default: GitHub Action Runner
     - name: "PERSONAL_ACCESS_TOKEN"
       prompt: "Please enter a personal access token for this workflow. Go to https://github.com/settings/tokens to get it."
       private: no
-      default: 2f6c50525175d7569067c7a2318e5f3dcf45714f
 
   tasks:
     - name: Verify that user exists on the server

--- a/ubuntu-virtualbox/playbook.yml
+++ b/ubuntu-virtualbox/playbook.yml
@@ -76,43 +76,46 @@
 
     - name: Enable starting the runner service when the machine starts
       become: yes
-      shell: systemctl enable actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+      systemd:
+        name: actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+        enabled: yes
       tags:
         - enable
 
     - name: Starting the runner service
       become: yes
-      shell: systemctl start actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+      systemd:
+        name: actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+        state: started
       tags:
         - start
 
     - name: Stopping the runner service
       become: yes
-      shell: systemctl stop actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+      systemd:
+        name: actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+        state: stopped
       tags:
         - never
         - stop
 
     - name: Disable starting the runner service when the system boots
       become: yes
-      shell: systemctl disable actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+      systemd:
+        name: actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+        enabled: no
       tags:
         - never
         - disable
 
     - name: Restart the runner service
       become: yes
-      shell: systemctl restart actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+      systemd:
+        name: actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+        state: restarted
       tags:
         - never
         - restart
-
-    - name: Show the runner service status
-      become: yes
-      shell: systemctl status actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
-      tags:
-        - never
-        - status
 
     - name: Unregister the runner with GitHub
       become: yes
@@ -123,7 +126,7 @@
         - never
         - uninstall
 
-    - name: Unregister the runner with GitHub and uninstall the runner service
+    - name: Uninstall the runner service
       shell:
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
         cmd: ./config.sh remove --token {{ CURL_OUTPUT.stdout }}

--- a/ubuntu-virtualbox/playbook.yml
+++ b/ubuntu-virtualbox/playbook.yml
@@ -12,9 +12,9 @@
     - name: "RUNNER_NAME"
       prompt: "Under what name should the runner show up on GitHub?"
       private: no
-      default: GitHub Action Runner
+      default: GitHubActionRunner
     - name: "PERSONAL_ACCESS_TOKEN"
-      prompt: "Please enter a personal access token for this workflow. Go to https://github.com/settings/tokens to get it."
+      prompt: "Please enter a personal access token for this workflow. Go to https://github.com/settings/tokens to get it"
       private: no
 
   tasks:
@@ -27,7 +27,7 @@
 
     - name: Showing the input variables
       debug:
-        msg: "Setting up a GitHub runner for repository: https://github.com/{{ ORG }}/{{ REPO }}"
+        msg: "Setting up a GitHub runner '{{ RUNNER_NAME }}' for repository: https://github.com/{{ ORG }}/{{ REPO }}"
 
     - name: Only run "apt update-cache" if the last one is more than 3600 seconds old
       become: yes
@@ -54,25 +54,25 @@
 
     - name: Creating a directory for the runner
       file:
-        path: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}
+        path: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
         state: directory
 
     - name: Downloading and extracting the runner
       unarchive:
         src: https://github.com/actions/runner/releases/download/v{{ RUNNER_VERSION }}/actions-runner-linux-x64-{{ RUNNER_VERSION }}.tar.gz
-        dest: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}
-        creates: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/config.sh
+        dest: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
+        creates: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}/config.sh
         remote_src: yes
 
     - name: Configuring the GitHub Action runner
       shell:
-        chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}
+        chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
         cmd: ./config.sh --url https://github.com/{{ ORG }}/{{ REPO }} --name {{ RUNNER_NAME }} --token {{ CURL_OUTPUT.stdout }} --unattended --replace
 
     - name: Install the GitHub Action runner as a service
       become: yes
       shell:
-        chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}
+        chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
         cmd: ./svc.sh install
 
     - name: Enable starting the runner service when the machine starts
@@ -118,7 +118,7 @@
     - name: Unregister the runner with GitHub
       become: yes
       shell:
-        chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}
+        chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
         cmd: ./svc.sh uninstall
       tags:
         - never
@@ -126,7 +126,7 @@
 
     - name: Unregister the runner with GitHub and uninstall the runner service
       shell:
-        chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}
+        chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
         cmd: ./config.sh remove --token {{ CURL_OUTPUT.stdout }}
       tags:
         - never

--- a/ubuntu-virtualbox/playbook.yml
+++ b/ubuntu-virtualbox/playbook.yml
@@ -2,6 +2,8 @@
 - hosts: all
   vars:
     RUNNER_VERSION: 2.169.1
+  vars_files:
+    - secret.yml
   vars_prompt:
     - name: "ORG"
       prompt: "What is the GitHub organization associated with this self-hosted runner?"
@@ -10,12 +12,9 @@
       prompt: "What is the GitHub repository associated with this self-hosted runner?"
       private: no
     - name: "RUNNER_NAME"
-      prompt: "Under what name should the runner show up on GitHub?"
+      prompt: "What is the runner's name on GitHub?"
       private: no
-      default: GitHubActionRunner
-    - name: "PERSONAL_ACCESS_TOKEN"
-      prompt: "Please enter a personal access token for this workflow. Go to https://github.com/settings/tokens to get it"
-      private: no
+      default: github-action-runner
 
   tasks:
     - name: Verify that user exists on the server

--- a/ubuntu-virtualbox/playbook.yml
+++ b/ubuntu-virtualbox/playbook.yml
@@ -66,6 +66,7 @@
     - name: Configuring the GitHub Action runner
       args:
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
+        creates: .runner
       command: ./config.sh --url https://github.com/{{ ORG }}/{{ REPO }} --name {{ RUNNER_NAME }} --token {{ CURL_OUTPUT.stdout }} --unattended --replace
 
     - name: Install the GitHub Action runner as a service
@@ -121,6 +122,7 @@
     - name: Unregister the runner with GitHub
       args:
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
+        removes: /etc/systemd/system/actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
       become: yes
       command: ./svc.sh uninstall
       tags:
@@ -130,6 +132,7 @@
     - name: Uninstall the runner service
       args:
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
+        removes: .runner
       command: ./config.sh remove --token {{ CURL_OUTPUT.stdout }}
       tags:
         - never

--- a/ubuntu-virtualbox/playbook.yml
+++ b/ubuntu-virtualbox/playbook.yml
@@ -56,7 +56,17 @@
       args:
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}/{{ RUNNER_NAME }}
         creates: .runner
-      command: ./config.sh --url https://github.com/{{ ORG }}/{{ REPO }} --name {{ RUNNER_NAME }} --token {{ URI_OUTPUT['json']['token'] }} --unattended --replace
+      command:
+        argv:
+          - ./config.sh
+          - --url
+          - "https://github.com/{{ ORG }}/{{ REPO }}"
+          - --name
+          - "{{ RUNNER_NAME }}"
+          - --token
+          - "{{ URI_OUTPUT['json']['token'] }}"
+          - --unattended
+          - --replace
 
     - name: Install the GitHub Action runner as a service
       args:

--- a/ubuntu-virtualbox/playbook.yml
+++ b/ubuntu-virtualbox/playbook.yml
@@ -5,14 +5,14 @@
   vars_files:
     - secret.yml
   vars_prompt:
-    - name: "ORG"
-      prompt: "What is the GitHub organization associated with this self-hosted runner?"
+    - name: ORG
+      prompt: What is the GitHub organization associated with this self-hosted runner?
       private: no
-    - name: "REPO"
-      prompt: "What is the GitHub repository associated with this self-hosted runner?"
+    - name: REPO
+      prompt: What is the GitHub repository associated with this self-hosted runner?
       private: no
-    - name: "RUNNER_NAME"
-      prompt: "What is the runner's name on GitHub?"
+    - name: RUNNER_NAME
+      prompt: What is the runner's name on GitHub?
       private: no
       default: github-action-runner
 
@@ -26,7 +26,7 @@
 
     - name: Showing the input variables
       debug:
-        msg: "Setting up a GitHub runner '{{ RUNNER_NAME }}' for repository: https://github.com/{{ ORG }}/{{ REPO }}"
+        msg: "Setting up a GitHub runner {{ RUNNER_NAME }} for repository: https://github.com/{{ ORG }}/{{ REPO }}"
 
     - name: Only run "apt update-cache" if the last one is more than 3600 seconds old
       become: yes
@@ -42,7 +42,7 @@
           - curl
         state: present
 
-    - name: "Requesting registration"
+    - name: Requesting registration
       shell:
         cmd: "curl -sX POST -H \"Authorization: token {{ PERSONAL_ACCESS_TOKEN }}\" \"https://api.github.com/repos/{{ ORG }}/{{ REPO }}/actions/runners/registration-token\" | jq .token --raw-output"
       register: CURL_OUTPUT

--- a/ubuntu-virtualbox/playbook.yml
+++ b/ubuntu-virtualbox/playbook.yml
@@ -4,19 +4,56 @@
     RUNNER_VERSION: 2.169.1
   vars_prompt:
     - name: "ORG"
-      prompt: "What is the GitHub organization for which you want to enable this self-hosted runner?"
+      prompt: "What is the GitHub organization associated with this self-hosted runner?"
       private: no
+      default: jspaaks
     - name: "REPO"
-      prompt: "What is the GitHub repository for which you want to enable this self-hosted runner?"
+      prompt: "What is the GitHub repository associated with this self-hosted runner?"
       private: no
-    - name: "TOKEN"
-      prompt: "Please enter the GitHub Actions token for this workflow. Go to https://github.com/<org>/<repo>/settings/actions/add-new-runner and copy it from the 'Configure' section."
+      default: example-python-1
+    - name: "RUNNER_NAME"
+      prompt: "Under what name should the runner show up on GitHub?"
       private: no
-  remote_user: tester
+      default: therunner1
+    - name: "PERSONAL_ACCESS_TOKEN"
+      prompt: "Please enter a personal access token for this workflow. Go to https://github.com/settings/tokens to get it."
+      private: no
+      default: 2f6c50525175d7569067c7a2318e5f3dcf45714f
+
   tasks:
+    - name: Verify that user exists on the server
+      become: True
+      user:
+        name: "{{ ansible_user }}"
+        groups: sudo,adm
+        state: present
+
     - name: Showing the input variables
       debug:
         msg: "Setting up a GitHub runner for repository: https://github.com/{{ ORG }}/{{ REPO }}"
+
+    - name: Only run "apt update-cache" if the last one is more than 3600 seconds old
+      become: True
+      apt:
+        update_cache: yes
+        cache_valid_time: 3600
+
+    - name: Install jq
+      become: True
+      apt:
+        name:
+          - jq
+          - curl
+        state: present
+
+    - name: "Requesting registration"
+      shell:
+        cmd: "curl -sX POST -H \"Authorization: token {{ PERSONAL_ACCESS_TOKEN }}\" \"https://api.github.com/repos/{{ ORG }}/{{ REPO }}/actions/runners/registration-token\" | jq .token --raw-output"
+      register: CURL_OUTPUT
+      tags:
+        - uninstall
+      args:
+        warn: false
 
     - name: Creating a directory for the runner
       file:
@@ -31,18 +68,69 @@
         remote_src: yes
 
     - name: Configuring the GitHub Action runner
-      command: chdir=/home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }} ./config.sh --unattended --url https://github.com/{{ ORG }}/{{ REPO }} --token {{ TOKEN }} --replace
+      shell:
+        chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}
+        cmd: ./config.sh --url https://github.com/{{ ORG }}/{{ REPO }} --name {{ RUNNER_NAME }} --token {{ CURL_OUTPUT.stdout }} --unattended --replace
 
     - name: Install the GitHub Action runner as a service
-      become: true
+      become: True
       shell:
         chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}
         cmd: ./svc.sh install
 
     - name: Enable starting the runner service when the machine starts
-      become: true
-      shell: systemctl enable actions.runner.{{ ORG }}-{{ REPO }}.{{ ansible_hostname }}.service
+      become: True
+      shell: systemctl enable actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+      tags:
+        - enable
 
     - name: Starting the runner service
-      become: true
-      shell: systemctl start actions.runner.{{ ORG }}-{{ REPO }}.{{ ansible_hostname }}.service
+      become: True
+      shell: systemctl start actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+      tags:
+        - start
+
+    - name: Stopping the runner service
+      become: True
+      shell: systemctl stop actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+      tags:
+        - never
+        - stop
+
+    - name: Disable starting the runner service when the system boots
+      become: True
+      shell: systemctl disable actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+      tags:
+        - never
+        - disable
+
+    - name: Restart the runner service
+      become: True
+      shell: systemctl restart actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+      tags:
+        - never
+        - restart
+
+    - name: Show the runner service status
+      become: True
+      shell: systemctl status actions.runner.{{ ORG }}-{{ REPO }}.{{ RUNNER_NAME }}.service
+      tags:
+        - never
+        - status
+
+    - name: Unregister the runner with GitHub
+      become: True
+      shell:
+        chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}
+        cmd: ./svc.sh uninstall
+      tags:
+        - never
+        - uninstall
+
+    - name: Unregister the runner with GitHub and uninstall the runner service
+      shell:
+        chdir: /home/tester/opt/actions-runner/{{ ORG }}/{{ REPO }}
+        cmd: ./config.sh remove --token {{ CURL_OUTPUT.stdout }}
+      tags:
+        - never
+        - uninstall

--- a/ubuntu-virtualbox/secret.yml
+++ b/ubuntu-virtualbox/secret.yml
@@ -1,1 +1,0 @@
-PERSONAL_ACCESS_TOKEN: <update this with your personal access token>

--- a/ubuntu-virtualbox/secret.yml
+++ b/ubuntu-virtualbox/secret.yml
@@ -1,0 +1,1 @@
+PERSONAL_ACCESS_TOKEN: <update this with your personal access token>

--- a/ubuntu-virtualbox/secret.yml.template
+++ b/ubuntu-virtualbox/secret.yml.template
@@ -1,0 +1,1 @@
+PERSONAL_ACCESS_TOKEN: <replace this with your personal access token>


### PR DESCRIPTION
- added check if user exists on server
- removed duplicate information 'remote_user' (now only uses ansible_user)
- added uninstall, restart, stop, start, enable, disable tasks that can be run using --tags

~~remaining open question, how to avoid having to ask for the personal access token a second time. Maybe store it in the remote machine?~~ **Update**: I added reading from a file ``secrets.txt``